### PR TITLE
Added company and individual settlor pages.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,5 +35,4 @@ tmp
 bin
 /*.iml
 /*.ipr
-/.classpath
 *.iws

--- a/app/uk/gov/hmrc/residencenilratebandcalculator/Constants.scala
+++ b/app/uk/gov/hmrc/residencenilratebandcalculator/Constants.scala
@@ -20,7 +20,9 @@ import uk.gov.hmrc.residencenilratebandcalculator.models.RadioOption
 
 object Constants {
   val companyDetailsId = "CompanyDetails"
+  val companySettlorId = "CompanySettlor"
   val individualDetailsId = "IndividualDetails"
+  val individualSettlorId = "IndividualSettlor"
   val typeOfSettlorId = "TypeOfSettlor"
   val typeOfTrustId = "TypeOfTrust"
 
@@ -30,6 +32,14 @@ object Constants {
   val companyOrIndividualOptions = Seq(
     RadioOption("type_of_trust", company),
     RadioOption("type_of_trust", individual)
+  )
+
+  val trading = "trading"
+  val investment = "investment"
+
+  val typeOfCompanyOptions = Seq(
+    RadioOption("type_of_company", trading),
+    RadioOption("type_of_company", investment)
   )
 
   val no = "No"

--- a/app/uk/gov/hmrc/residencenilratebandcalculator/Navigator.scala
+++ b/app/uk/gov/hmrc/residencenilratebandcalculator/Navigator.scala
@@ -30,7 +30,8 @@ class Navigator @Inject()() {
     Map(
       Constants.typeOfTrustId -> (ua => getTypeOfTrustRoute(ua)),
       Constants.companyDetailsId -> (ua => TypeOfSettlorController.onPageLoad()),
-      Constants.individualDetailsId -> (ua => TypeOfSettlorController.onPageLoad())
+      Constants.individualDetailsId -> (ua => TypeOfSettlorController.onPageLoad()),
+      Constants.typeOfSettlorId -> (ua => getTypeOfSettlorRoute(ua))
     )
   }
 
@@ -40,10 +41,15 @@ class Navigator @Inject()() {
     case _ => PageNotFoundController.onPageLoad() // Probably want to go to a start page instead
   }
 
+  private def getTypeOfSettlorRoute(userAnswers: UserAnswers): Call = userAnswers.typeOfSettlor match {
+    case Some(Constants.company) => CompanySettlorController.onPageLoad()
+    case Some(Constants.individual) => IndividualSettlorController.onPageLoad()
+    case _ => PageNotFoundController.onPageLoad() // Probably want to go to a start page instead
+  }
+
   def nextPage(controllerId: String): UserAnswers => Call = {
     routeMap.getOrElse(controllerId, _ => PageNotFoundController.onPageLoad())
   }
 
   private def goToPageNotFound: UserAnswers => Call = _ => PageNotFoundController.onPageLoad()
-
 }

--- a/app/uk/gov/hmrc/residencenilratebandcalculator/connectors/CascadeUpsert.scala
+++ b/app/uk/gov/hmrc/residencenilratebandcalculator/connectors/CascadeUpsert.scala
@@ -30,7 +30,8 @@ class CascadeUpsert {
 
   val funcMap: Map[String, (JsValue, CacheMap) => CacheMap] =
     Map(
-      Constants.typeOfTrustId -> ((v, cm) => cleanupTypeOfTrust(v, cm))
+      Constants.typeOfTrustId -> ((v, cm) => cleanupTypeOfTrust(v, cm)),
+      Constants.typeOfSettlorId -> ((v, cm) => cleanupTypeOfSettlor(v, cm))
     )
 
   private def store[A](key:String, value: A, cacheMap: CacheMap)(implicit wrts: Writes[A]) =
@@ -45,11 +46,20 @@ class CascadeUpsert {
   }
 
   private def cleanupTypeOfTrust[A](value: A, cacheMap: CacheMap)(implicit wrts: Writes[A]): CacheMap = {
-      val mapToStore = value match {
+    val mapToStore = value match {
       case JsString(Constants.company) => cacheMap copy (data = cacheMap.data.filterKeys(s => s != Constants.individualDetailsId))
       case JsString(Constants.individual) => cacheMap copy (data = cacheMap.data.filterKeys(s => s != Constants.companyDetailsId))
       case _ => cacheMap
     }
     store(Constants.typeOfTrustId, value, mapToStore)
+  }
+
+  private def cleanupTypeOfSettlor[A](value: A, cacheMap: CacheMap)(implicit wrts: Writes[A]): CacheMap = {
+    val mapToStore = value match {
+      case JsString(Constants.company) => cacheMap copy (data = cacheMap.data.filterKeys(s => s != Constants.individualSettlorId))
+      case JsString(Constants.individual) => cacheMap copy (data = cacheMap.data.filterKeys(s => s != Constants.companySettlorId))
+      case _ => cacheMap
+    }
+    store(Constants.typeOfSettlorId, value, mapToStore)
   }
 }

--- a/app/uk/gov/hmrc/residencenilratebandcalculator/controllers/CompanySettlorController.scala
+++ b/app/uk/gov/hmrc/residencenilratebandcalculator/controllers/CompanySettlorController.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.residencenilratebandcalculator.controllers
+
+import javax.inject.Inject
+
+import play.api.data.Form
+import play.api.i18n.MessagesApi
+import play.api.mvc.Request
+import uk.gov.hmrc.residencenilratebandcalculator.{Constants, FrontendAppConfig, Navigator}
+import uk.gov.hmrc.residencenilratebandcalculator.connectors.SessionConnector
+import uk.gov.hmrc.residencenilratebandcalculator.forms.CompanySettlorForm
+import uk.gov.hmrc.residencenilratebandcalculator.models.{CompanySettlor, UserAnswers}
+import uk.gov.hmrc.residencenilratebandcalculator.views.html.company_settlor
+
+class CompanySettlorController @Inject()(override val appConfig: FrontendAppConfig,
+                                         val messagesApi: MessagesApi,
+                                         override val sessionConnector: SessionConnector,
+                                         override val navigator: Navigator) extends SimpleControllerBase[CompanySettlor]{
+
+  override val controllerId = Constants.companySettlorId
+
+  override def form = () => CompanySettlorForm()
+
+  override def view(form: Option[Form[CompanySettlor]], userAnswers: UserAnswers)(implicit request: Request[_]) = {
+    company_settlor(appConfig, form)
+  }
+}

--- a/app/uk/gov/hmrc/residencenilratebandcalculator/controllers/IndividualSettlorController.scala
+++ b/app/uk/gov/hmrc/residencenilratebandcalculator/controllers/IndividualSettlorController.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.residencenilratebandcalculator.controllers
+
+import javax.inject.Inject
+
+import play.api.data.Form
+import play.api.i18n.MessagesApi
+import play.api.mvc.Request
+import uk.gov.hmrc.residencenilratebandcalculator.{Constants, FrontendAppConfig, Navigator}
+import uk.gov.hmrc.residencenilratebandcalculator.connectors.SessionConnector
+import uk.gov.hmrc.residencenilratebandcalculator.forms.IndividualSettlorForm
+import uk.gov.hmrc.residencenilratebandcalculator.models.{IndividualSettlor, UserAnswers}
+import uk.gov.hmrc.residencenilratebandcalculator.views.html.individual_settlor
+
+class IndividualSettlorController @Inject()(override val appConfig: FrontendAppConfig,
+                                         val messagesApi: MessagesApi,
+                                         override val sessionConnector: SessionConnector,
+                                         override val navigator: Navigator) extends SimpleControllerBase[IndividualSettlor]{
+
+  override val controllerId = Constants.individualSettlorId
+
+  override def form = () => IndividualSettlorForm()
+
+  override def view(form: Option[Form[IndividualSettlor]], userAnswers: UserAnswers)(implicit request: Request[_]) = {
+    individual_settlor(appConfig, form)
+  }
+}

--- a/app/uk/gov/hmrc/residencenilratebandcalculator/forms/CompanySettlorForm.scala
+++ b/app/uk/gov/hmrc/residencenilratebandcalculator/forms/CompanySettlorForm.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.residencenilratebandcalculator.forms
+
+import play.api.data.Form
+import play.api.data.Forms._
+import uk.gov.hmrc.residencenilratebandcalculator.Constants
+import uk.gov.hmrc.residencenilratebandcalculator.models.CompanySettlor
+
+object CompanySettlorForm extends WithRequiredBooleanMapping {
+
+  private def isValidTypeOfCompanyOption(value: String) =
+    Constants.typeOfCompanyOptions.exists(radioOption => radioOption.value == value)
+
+  def apply(): Form[CompanySettlor] = Form(
+    mapping(
+      "name" -> nonEmptyText,
+      "ukCompany" -> of[Boolean](requiredBooleanFormatter),
+      "typeOfCompany" -> nonEmptyText.verifying(x => isValidTypeOfCompanyOption(x)),
+      "atLeastTwoYearsOld" -> of[Boolean](requiredBooleanFormatter)
+    )(CompanySettlor.apply)(CompanySettlor.unapply)
+  )
+}

--- a/app/uk/gov/hmrc/residencenilratebandcalculator/forms/DateForm.scala
+++ b/app/uk/gov/hmrc/residencenilratebandcalculator/forms/DateForm.scala
@@ -39,7 +39,7 @@ object DateForm {
         case None => produceError(key, errorKeyBlank)
         case Some("") => produceError(key, errorKeyBlank)
         case Some(d) => d match {
-          case intRegex(v) if v.toInt <= upperBound => Right(v.toInt)
+          case intRegex(v) if v.toInt > 0 && v.toInt <= upperBound => Right(v.toInt)
           case _ => produceError(key, errorKeyOutOfRange)
         }
       }

--- a/app/uk/gov/hmrc/residencenilratebandcalculator/forms/IndividualSettlorForm.scala
+++ b/app/uk/gov/hmrc/residencenilratebandcalculator/forms/IndividualSettlorForm.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.residencenilratebandcalculator.forms
+
+import play.api.data.Form
+import play.api.data.Forms._
+import uk.gov.hmrc.residencenilratebandcalculator.forms.DateForm.{datePartFormatter, upperBoundDays, upperBoundMonths, upperBoundYears}
+import uk.gov.hmrc.residencenilratebandcalculator.forms.FormValidators.isValidDate
+import uk.gov.hmrc.residencenilratebandcalculator.models.{Date, IndividualSettlor}
+import uk.gov.voa.play.form.ConditionalMappings._
+
+object IndividualSettlorForm extends WithRequiredBooleanMapping {
+
+  def apply(): Form[IndividualSettlor] = Form(
+    mapping(
+      "firstName" -> nonEmptyText,
+      "middleNames" -> optional(text),
+      "lastName" -> nonEmptyText,
+      "dateOfBirth" -> mapping(
+        "day" -> of(datePartFormatter("error.date.day_blank", "error.date.day_invalid", upperBoundDays)),
+        "month" -> of(datePartFormatter("error.date.month_blank", "error.date.month_invalid", upperBoundMonths)),
+        "year" -> of(datePartFormatter("error.date.year_blank", "error.date.year_invalid", upperBoundYears))
+      )(Date.apply)(Date.unapply)
+        .verifying("error.invalid_date", fields => isValidDate(fields.day, fields.month, fields.year)),
+      "hasNino" -> of[Boolean](requiredBooleanFormatter),
+      "nino" -> mandatoryIfTrue("hasNino", nonEmptyText),
+      "phoneNumber" -> nonEmptyText
+    )(IndividualSettlor.apply)(IndividualSettlor.unapply)
+  )
+}

--- a/app/uk/gov/hmrc/residencenilratebandcalculator/models/CompanySettlor.scala
+++ b/app/uk/gov/hmrc/residencenilratebandcalculator/models/CompanySettlor.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.residencenilratebandcalculator.models
+
+import play.api.libs.json._
+
+case class CompanySettlor (name: String,
+                           ukCompany: Boolean,
+                           typeOfCompany: String,
+                           atLeastTwoYearsOld: Boolean)
+
+object CompanySettlor {
+  implicit val reads = Json.reads[CompanySettlor]
+  implicit val writes = Json.writes[CompanySettlor]
+}

--- a/app/uk/gov/hmrc/residencenilratebandcalculator/models/IndividualSettlor.scala
+++ b/app/uk/gov/hmrc/residencenilratebandcalculator/models/IndividualSettlor.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.residencenilratebandcalculator.models
+
+import play.api.libs.json.Json
+
+case class IndividualSettlor (firstName: String,
+                              middleNames: Option[String],
+                              lastName: String,
+                              dateOfBirth: Date,
+                              hasNino: Boolean,
+                              nino: Option[String],
+                              phoneNumber: String)
+
+object IndividualSettlor {
+  implicit val reads = Json.reads[IndividualSettlor]
+  implicit val writes = Json.writes[IndividualSettlor]
+}

--- a/app/uk/gov/hmrc/residencenilratebandcalculator/views/company_settlor.scala.html
+++ b/app/uk/gov/hmrc/residencenilratebandcalculator/views/company_settlor.scala.html
@@ -1,0 +1,53 @@
+@import uk.gov.hmrc.residencenilratebandcalculator.FrontendAppConfig
+@import uk.gov.hmrc.play.views.html._
+@import uk.gov.hmrc.residencenilratebandcalculator.controllers.routes._
+@import uk.gov.hmrc.residencenilratebandcalculator.utils.FormHelpers
+@import uk.gov.hmrc.residencenilratebandcalculator.Constants
+@import uk.gov.hmrc.residencenilratebandcalculator.models.CompanySettlor
+
+@(appConfig: FrontendAppConfig, form: Option[Form[CompanySettlor]] = None)(implicit request: Request[_], messages: Messages)
+
+@uk.gov.hmrc.residencenilratebandcalculator.views.html.main_template(
+    title = messages("company_settlor.browser_title"),
+    appConfig = appConfig,
+    bodyClasses = None) {
+
+    @helpers.form(action = CompanySettlorController.onSubmit(), 'autoComplete -> "off") {
+
+        @rnrbHelpers.error_summary(FormHelpers.getAllErrors(form))
+
+        @rnrbHelpers.heading("company_settlor.title")
+
+        @rnrbHelpers.input_text(id = "name", name = "name", errorKey = FormHelpers.getErrorByKey(form, "name"),
+            label = messages("company_settlor.name"), value = Some(FormHelpers.getValueByKey(form, "name")))
+
+        @rnrbHelpers.input_yes_no(
+            id = "ukCompany",
+            label = messages("company_settlor.uk_company"),
+            labelClass = Some("bold"),
+            errorKey = FormHelpers.getErrorByKey(form, "ukCompany"),
+            hint = Some(messages("company_settlor.uk_company.hint")),
+            value = Some(FormHelpers.getValueByKey(form, "ukCompany"))
+        )
+
+        @rnrbHelpers.input_radio(
+            name = "typeOfCompany",
+            legend = messages("company_settlor.type_of_company"),
+            legendClass = Some("bold"),
+            errorKey = FormHelpers.getErrorByKey(form, "typeOfCompany"),
+            inputs = Constants.typeOfCompanyOptions,
+            value = Some(FormHelpers.getValueByKey[CompanySettlor](form, "typeOfCompany"))
+        )
+
+        @rnrbHelpers.input_yes_no(
+            id = "atLeastTwoYearsOld",
+            label = messages("company_settlor.at_least_two_years_old"),
+            labelClass = Some("bold"),
+            errorKey = FormHelpers.getErrorByKey(form, "atLeastTwoYearsOld"),
+            value = Some(FormHelpers.getValueByKey(form, "atLeastTwoYearsOld"))
+        )
+
+        @rnrbHelpers.submit_button()
+    }
+}
+

--- a/app/uk/gov/hmrc/residencenilratebandcalculator/views/individual_settlor.scala.html
+++ b/app/uk/gov/hmrc/residencenilratebandcalculator/views/individual_settlor.scala.html
@@ -1,0 +1,61 @@
+@import uk.gov.hmrc.residencenilratebandcalculator.FrontendAppConfig
+@import uk.gov.hmrc.play.views.html._
+@import uk.gov.hmrc.residencenilratebandcalculator.controllers.routes._
+@import uk.gov.hmrc.residencenilratebandcalculator.utils.FormHelpers
+@import uk.gov.hmrc.residencenilratebandcalculator.Constants
+@import uk.gov.hmrc.residencenilratebandcalculator.models.IndividualSettlor
+
+@(appConfig: FrontendAppConfig, form: Option[Form[IndividualSettlor]] = None)(implicit request: Request[_], messages: Messages)
+
+@uk.gov.hmrc.residencenilratebandcalculator.views.html.main_template(
+    title = messages("individual_settlor.browser_title"),
+    appConfig = appConfig,
+    bodyClasses = None) {
+
+    @helpers.form(action = IndividualSettlorController.onSubmit(), 'autoComplete -> "off") {
+
+        @rnrbHelpers.error_summary(FormHelpers.getAllErrors(form))
+
+        @rnrbHelpers.heading("individual_settlor.title")
+
+        @rnrbHelpers.input_text(id = "firstName", name = "firstName", errorKey = FormHelpers.getErrorByKey(form, "firstName"),
+            label = messages("individual_settlor.first_name"), value = Some(FormHelpers.getValueByKey(form, "firstName")))
+
+        @rnrbHelpers.input_text(id = "middleNames", name = "middleNames", errorKey = FormHelpers.getErrorByKey(form, "middleNames"),
+            label = messages("individual_settlor.middle_names"), value = Some(FormHelpers.getValueByKey(form, "middleNames")))
+
+        @rnrbHelpers.input_text(id = "lastName", name = "lastName", errorKey = FormHelpers.getErrorByKey(form, "lastName"),
+            label = messages("individual_settlor.last_name"), value = Some(FormHelpers.getValueByKey(form, "lastName")))
+
+        @rnrbHelpers.input_date(
+            id = "dateOfBirth",
+            label = messages("individual_settlor.date_of_birth"),
+            hint = Some(messages("individual_settlor.date_of_birth.hint")),
+            errorKey = FormHelpers.getErrorByKey(form, ""),
+            dayErrorKey = FormHelpers.getErrorByKey(form, "dateOfBirth.day"),
+            monthErrorKey = FormHelpers.getErrorByKey(form, "dateOfBirth.month"),
+            yearErrorKey = FormHelpers.getErrorByKey(form, "dateOfBirth.year"),
+            valueDay = Some(FormHelpers.getValueByKey(form, "dateOfBirth.day").toString),
+            valueMonth = Some(FormHelpers.getValueByKey(form, "dateOfBirth.month").toString),
+            valueYear = Some(FormHelpers.getValueByKey(form, "dateOfBirth.year").toString)
+        )
+
+        @rnrbHelpers.input_yes_no(
+            id = "hasNino",
+            label = messages("individual_settlor.has_nino"),
+            labelClass = Some("bold"),
+            errorKey = FormHelpers.getErrorByKey(form, "hasNino"),
+            value = Some(FormHelpers.getValueByKey(form, "hasNino"))
+        )
+
+        @rnrbHelpers.input_text(id = "nino", name = "nino", errorKey = FormHelpers.getErrorByKey(form, "nino"),
+            label = messages("individual_settlor.nino"), hint = Some(messages("individual_settlor.nino.hint")), value = Some(FormHelpers.getValueByKey(form, "nino")))
+
+        @rnrbHelpers.input_text(id = "phoneNumber", name = "phoneNumber", errorKey = FormHelpers.getErrorByKey(form, "phoneNumber"),
+            label = messages("individual_settlor.phone_number"), hint = Some(messages("individual_settlor.phone_number.hint")),
+            value = Some(FormHelpers.getValueByKey(form, "phoneNumber")))
+
+        @rnrbHelpers.submit_button()
+    }
+}
+

--- a/app/uk/gov/hmrc/residencenilratebandcalculator/views/rnrbHelpers/input_yes_no.scala.html
+++ b/app/uk/gov/hmrc/residencenilratebandcalculator/views/rnrbHelpers/input_yes_no.scala.html
@@ -22,12 +22,12 @@ labelClass: Option[String] = None
         @if(errorKey.nonEmpty){
         <span class="error-notification" id="error-message-this-input">@messages(errorKey)</span>
         }
-        <label class="block-label selection-button-radio" for="yes" data-target="@if(yesAssoc.nonEmpty){@yesAssoc}">
-            <input id="yes" type="radio" name="@{id}" value="true" @if(value.contains("true")){checked="checked"} />
+        <label class="block-label selection-button-radio" for="@{id}-yes" data-target="@if(yesAssoc.nonEmpty){@yesAssoc}">
+            <input id="@{id}-yes" type="radio" name="@{id}" value="true" @if(value.contains("true")){checked="checked"} />
             @messages("site.yes")
         </label>
-        <label class="block-label selection-button-radio" for="no" data-target="@if(noAssoc.nonEmpty){@noAssoc}">
-            <input id="no" type="radio" name="@{id}" value="false" @if(value.contains("false")){checked="checked"} />
+        <label class="block-label selection-button-radio" for="@{id}-no" data-target="@if(noAssoc.nonEmpty){@noAssoc}">
+            <input id="@{id}-no" type="radio" name="@{id}" value="false" @if(value.contains("false")){checked="checked"} />
             @messages("site.no")
         </label>
 

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -10,8 +10,14 @@ GET        /not-found                                   uk.gov.hmrc.residencenil
 GET         /company-details                            uk.gov.hmrc.residencenilratebandcalculator.controllers.CompanyDetailsController.onPageLoad
 POST        /company-details                            uk.gov.hmrc.residencenilratebandcalculator.controllers.CompanyDetailsController.onSubmit
 
+GET         /company-settlor                            uk.gov.hmrc.residencenilratebandcalculator.controllers.CompanySettlorController.onPageLoad
+POST        /company-settlor                            uk.gov.hmrc.residencenilratebandcalculator.controllers.CompanySettlorController.onSubmit
+
 GET         /individual-details                         uk.gov.hmrc.residencenilratebandcalculator.controllers.IndividualDetailsController.onPageLoad
 POST        /individual-details                         uk.gov.hmrc.residencenilratebandcalculator.controllers.IndividualDetailsController.onSubmit
+
+GET         /individual-settlor                         uk.gov.hmrc.residencenilratebandcalculator.controllers.IndividualSettlorController.onPageLoad
+POST        /individual-settlor                         uk.gov.hmrc.residencenilratebandcalculator.controllers.IndividualSettlorController.onSubmit
 
 GET         /type-of-settlor                            uk.gov.hmrc.residencenilratebandcalculator.controllers.TypeOfSettlorController.onPageLoad
 POST        /type-of-settlor                            uk.gov.hmrc.residencenilratebandcalculator.controllers.TypeOfSettlorController.onSubmit

--- a/conf/messages
+++ b/conf/messages
@@ -1,14 +1,23 @@
-company_details.browser_title = Comapny Details
+company_details.browser_title = Company Details
 company_details.title = Enter your company details
 company_details.name = Company name
 company_details.uk_company = Is it a UK company with a Unique Taxpayer Reference (UTR) number?
 company_details.uk_company.hint = This is a 10 digit number, like 1234567890.  You can find this on your company tax returns, statement of accounts or any other self-assessment calculations.
 company_details.contact_email = Contact email address (optional)
 
+company_settlor.browser_title = Settlor's Company Details
+company_settlor.title = Enter the settlor's company details
+company_settlor.name = Company name
+company_settlor.uk_company = Is it a UK company with a Unique Taxpayer Reference (UTR) number?
+company_settlor.uk_company.hint = This is a 10 digit number, like 1234567890.  You can find this on your company tax returns, statement of accounts or any other self-assessment calculations.
+company_settlor.type_of_company = What type of company is the settlor of the trust?
+company_settlor.at_least_two_years_old = At the date of each contribution to the trust, had the company been in existence for at least 2 years?
+
 date.day = Day
 date.month = Month
 date.year = Year
 
+error.boolean = Please give an answer
 error.invalid_company_or_individual_option = Give an answer for type of trust
 error.invalid_date = Give a correct date
 error.date.day_blank = Enter a day
@@ -25,7 +34,7 @@ error.summary.text = Check the following
 error.whole_pounds = Give a value in whole pounds only without any pence
 
 individual_details.browser_title = Your details
-individual_details.title = Enter your detials
+individual_details.title = Enter your details
 individual_details.first_name = First name
 individual_details.middle_names = Middle names (optional)
 individual_details.last_name = Last name
@@ -37,6 +46,19 @@ individual_details.nino.hint = For example, AA111111A
 individual_details.phone_number = Telephone number
 individual_details.phone_number.hint = If this is a UK landline or an overseas number, you must include the area or dialing code
 individual_details.contact_email = Contact email address (optional)
+
+individual_settlor.browser_title = Settlor's details
+individual_settlor.title = Enter the settlor's details
+individual_settlor.first_name = First name
+individual_settlor.middle_names = Middle names (optional)
+individual_settlor.last_name = Last name
+individual_settlor.date_of_birth = Date of birth
+individual_settlor.date_of_birth.hint = For example 20 03 1976
+individual_settlor.has_nino = Does the settlor have a UK National Insurance number?
+individual_settlor.nino = National Insurance number
+individual_settlor.nino.hint = For example, AA111111A
+individual_settlor.phone_number = Telephone number
+individual_settlor.phone_number.hint = If this is a UK landline or an overseas number, you must include the area or dialing code
 
 session_expired.browser_title = For your security, this service has been reset
 session_expired.title = For your security, this service has been reset
@@ -59,6 +81,9 @@ site.service_name = Register a trust for tax
 type_of_settlor.browser_title = Type of Settlor
 type_of_settlor.title = Select the type of settlor
 type_of_settlor.guidance1 = Are they a company or individual?
+
+type_of_company.trading = Trading
+type_of_company.investment = Investment
 
 type_of_trust.browser_title = Type of Trust
 type_of_trust.title = Select the type of trustee managing the trust

--- a/project/FrontendBuild.scala
+++ b/project/FrontendBuild.scala
@@ -32,6 +32,7 @@ private object AppDependencies {
   private val playReactivemongoVersion = "5.1.0"
   private val pdfBoxVersion = "2.0.4"
   private val graphiteVersion = "3.2.0"
+  private val playConditionalFormMappingVersion = "0.2.0"
 
   val compile = Seq(
     "uk.gov.hmrc" %% "play-reactivemongo" % playReactivemongoVersion,
@@ -46,6 +47,7 @@ private object AppDependencies {
     "uk.gov.hmrc" %% "play-ui" % playUiVersion,
     "uk.gov.hmrc" %% "play-whitelist-filter" % whitelistVersion,
     "uk.gov.hmrc" %% "http-caching-client" % httpCachingClientVersion,
+    "uk.gov.hmrc" %% "play-conditional-form-mapping" % playConditionalFormMappingVersion,
     "com.eclipsesource" %% "play-json-schema-validator" % playJsonValidatorVersion,
     "uk.gov.hmrc" %% "play-graphite" % graphiteVersion,
     "org.apache.pdfbox" % "pdfbox" % pdfBoxVersion

--- a/test/uk/gov/hmrc/residencenilratebandcalculator/NavigatorSpec.scala
+++ b/test/uk/gov/hmrc/residencenilratebandcalculator/NavigatorSpec.scala
@@ -17,9 +17,11 @@
 package uk.gov.hmrc.residencenilratebandcalculator
 
 import org.joda.time.LocalDate
+import org.mockito.Matchers._
 import org.mockito.Mockito._
 import org.scalatest.Matchers
 import org.scalatest.mock.MockitoSugar
+import play.api.libs.json.JsString
 import uk.gov.hmrc.http.cache.client.CacheMap
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
 import uk.gov.hmrc.residencenilratebandcalculator.controllers.routes
@@ -27,4 +29,18 @@ import uk.gov.hmrc.residencenilratebandcalculator.models.UserAnswers
 
 class NavigatorSpec extends UnitSpec with MockitoSugar with Matchers with WithFakeApplication {
   val navigator = new Navigator
+
+  "Navigator" must {
+    "go to Company Settlor from Type Of Settlor when the type of settlor is Company" in {
+      val cacheMap = CacheMap("a", Map(Constants.typeOfSettlorId -> JsString(Constants.company)))
+      val userAnswers = new UserAnswers(cacheMap)
+      navigator.nextPage(Constants.typeOfSettlorId)(userAnswers) shouldBe routes.CompanySettlorController.onPageLoad
+    }
+
+    "go to Individual Settlor from Type Of Settlor when the type of settlor is Individual" in {
+      val cacheMap = CacheMap("a", Map(Constants.typeOfSettlorId -> JsString(Constants.individual)))
+      val userAnswers = new UserAnswers(cacheMap)
+      navigator.nextPage(Constants.typeOfSettlorId)(userAnswers) shouldBe routes.IndividualSettlorController.onPageLoad
+    }
+  }
 }

--- a/test/uk/gov/hmrc/residencenilratebandcalculator/connectors/CascadeUpsertSpec.scala
+++ b/test/uk/gov/hmrc/residencenilratebandcalculator/connectors/CascadeUpsertSpec.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.residencenilratebandcalculator.connectors
+
+import play.api.libs.json.{JsString, Json}
+import uk.gov.hmrc.http.cache.client.CacheMap
+import uk.gov.hmrc.play.test.UnitSpec
+import uk.gov.hmrc.residencenilratebandcalculator.Constants
+import uk.gov.hmrc.residencenilratebandcalculator.models.{CompanySettlor, Date, IndividualSettlor}
+
+class CascadeUpsertSpec extends UnitSpec {
+
+  val cacheMapId = "id"
+
+  "Cascade upsert" when {
+
+    "asked to save the answer 'company' as the type of settlor" must {
+      val individualSettlor = Json.toJson(IndividualSettlor("firstName", None, "lastName", Date(1, 2, 2000), false, None, "01234 567890"))
+      val cacheMap = CacheMap(cacheMapId, Map(Constants.individualSettlorId -> individualSettlor))
+      val updatedCacheMap = (new CascadeUpsert)(Constants.typeOfSettlorId, Constants.company, cacheMap)
+
+      "delete any existing value for 'individual settlor'" in {
+        updatedCacheMap.data.keys should not contain Constants.individualSettlorId
+      }
+
+      "save the type of settlor" in {
+        updatedCacheMap.data(Constants.typeOfSettlorId) shouldBe JsString(Constants.company)
+      }
+    }
+
+    "asked to save the answer 'individual' as the type of settlor" must {
+      val companySettlor = Json.toJson(CompanySettlor("name", true, Constants.trading, true))
+      val cacheMap = CacheMap(cacheMapId, Map(Constants.companySettlorId -> companySettlor))
+      val updatedCacheMap = (new CascadeUpsert)(Constants.typeOfSettlorId, Constants.individual, cacheMap)
+
+      "delete any existing value for 'company settlor'" in {
+        updatedCacheMap.data.keys should not contain Constants.individualSettlorId
+      }
+
+      "save the type of settlor" in {
+        updatedCacheMap.data(Constants.typeOfSettlorId) shouldBe JsString(Constants.individual)
+      }
+    }
+  }
+}

--- a/test/uk/gov/hmrc/residencenilratebandcalculator/controllers/CompanySettlorControllerSpec.scala
+++ b/test/uk/gov/hmrc/residencenilratebandcalculator/controllers/CompanySettlorControllerSpec.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.residencenilratebandcalculator.controllers
+
+import play.api.libs.json.{JsObject, JsValue, Json}
+import uk.gov.hmrc.residencenilratebandcalculator.Constants
+import uk.gov.hmrc.residencenilratebandcalculator.forms.CompanySettlorForm
+import uk.gov.hmrc.residencenilratebandcalculator.models.CompanySettlor
+import uk.gov.hmrc.residencenilratebandcalculator.views.html.company_settlor
+
+class CompanySettlorControllerSpec extends SimpleControllerSpecBase {
+
+  "Company settlor controller" must {
+    def createView = (value: Option[CompanySettlor]) => {
+      value match {
+        case None => company_settlor(frontendAppConfig)(fakeRequest, messages)
+        case Some(v) => company_settlor(frontendAppConfig, Some(CompanySettlorForm().fill(v)))(fakeRequest, messages)
+      }
+    }
+
+    def createController = () => new CompanySettlorController(frontendAppConfig, messagesApi, mockSessionConnector, navigator)
+
+    val testValue = CompanySettlor("name", true, Constants.trading, true)
+
+    val invalidData: JsValue = Json.toJson(testValue).as[JsObject] - "name"
+
+    val valuesToCache = Map(Constants.typeOfTrustId -> Constants.company)
+
+    val cacheKey = Constants.companySettlorId
+
+    behave like multiQuestionController[CompanySettlor](createController, createView, Constants.companySettlorId, testValue,
+      invalidData)(CompanySettlor.reads, CompanySettlor.writes)
+  }
+}

--- a/test/uk/gov/hmrc/residencenilratebandcalculator/controllers/IndividualSettlorControllerSpec.scala
+++ b/test/uk/gov/hmrc/residencenilratebandcalculator/controllers/IndividualSettlorControllerSpec.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.residencenilratebandcalculator.controllers
+
+import play.api.libs.json.{JsObject, JsValue, Json}
+import uk.gov.hmrc.residencenilratebandcalculator.Constants
+import uk.gov.hmrc.residencenilratebandcalculator.forms.IndividualSettlorForm
+import uk.gov.hmrc.residencenilratebandcalculator.models.{Date, IndividualSettlor}
+import uk.gov.hmrc.residencenilratebandcalculator.views.html.individual_settlor
+
+class IndividualSettlorControllerSpec extends SimpleControllerSpecBase {
+
+  "Individual settlor controller" must {
+    def createView = (value: Option[IndividualSettlor]) => {
+      value match {
+        case None => individual_settlor(frontendAppConfig)(fakeRequest, messages)
+        case Some(v) => individual_settlor(frontendAppConfig, Some(IndividualSettlorForm().fill(v)))(fakeRequest, messages)
+      }
+    }
+
+    def createController = () => new IndividualSettlorController(frontendAppConfig, messagesApi, mockSessionConnector, navigator)
+
+    val testValue = IndividualSettlor("first name", None, "last name", Date(1, 2, 2000), false, None, "01234 567890")
+
+    val invalidData: JsValue = Json.toJson(testValue).as[JsObject] - "firstName"
+
+    val valuesToCache = Map(Constants.typeOfTrustId -> Constants.individual)
+
+    val cacheKey = Constants.individualSettlorId
+
+    behave like multiQuestionController[IndividualSettlor](createController, createView, Constants.individualSettlorId, testValue,
+      invalidData)(IndividualSettlor.reads, IndividualSettlor.writes)
+  }
+}

--- a/test/uk/gov/hmrc/residencenilratebandcalculator/forms/CompanySettlorFormSpec.scala
+++ b/test/uk/gov/hmrc/residencenilratebandcalculator/forms/CompanySettlorFormSpec.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.residencenilratebandcalculator.forms
+
+import uk.gov.hmrc.residencenilratebandcalculator.Constants
+import uk.gov.hmrc.residencenilratebandcalculator.models.CompanySettlor
+
+class CompanySettlorFormSpec extends FormBehaviours {
+
+  val validData: Map[String, String] = Map(
+    "name" -> "a name",
+    "ukCompany" -> "true",
+    "typeOfCompany" -> Constants.trading,
+    "atLeastTwoYearsOld" -> "true"
+  )
+
+  val form = CompanySettlorForm()
+
+  "Company Settlor form" must {
+    behave like trustsForm[CompanySettlor](CompanySettlor("a name", true, Constants.trading, true))
+
+    behave like formWithMandatoryTextFields("name")
+
+    behave like formWithBooleans("ukCompany", "atLeastTwoYearsOld")
+
+    behave like formWithOptionField("typeOfCompany", Constants.trading, Constants.investment)
+  }
+}

--- a/test/uk/gov/hmrc/residencenilratebandcalculator/forms/FormBehaviours.scala
+++ b/test/uk/gov/hmrc/residencenilratebandcalculator/forms/FormBehaviours.scala
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.residencenilratebandcalculator.forms
+
+import play.api.data.Form
+import play.api.libs.json.Json
+import uk.gov.hmrc.play.test.UnitSpec
+import uk.gov.hmrc.residencenilratebandcalculator.models.{Date, IndividualSettlor}
+
+trait FormBehaviours extends FormSpec {
+
+  val validData: Map[String, String]
+
+  val form: Form[_]
+
+  def trustsForm[A](expectedResult: A) = {
+    "bind valid values correctly" in {
+      val boundForm = form.bind(validData)
+      boundForm.get shouldBe expectedResult
+    }
+  }
+
+  def formWithOptionalTextFields(fields: String*) = {
+    for (field <- fields) {
+      val data = validData - field
+      val boundForm = form.bind(data)
+      boundForm.errors.isEmpty shouldBe true
+    }
+  }
+
+  def formWithMandatoryTextFields(fields: String*) = {
+    for (field <- fields) {
+      s"fail to bind when $field is omitted" in {
+        val data = validData - field
+        val expectedError = error(field, "error.required")
+        checkForError(form, data, expectedError)
+      }
+
+      s"fail to bind when $field is blank" in {
+        val data = validData + (field -> "")
+        val expectedError = error(field, "error.required")
+        checkForError(form, data, expectedError)
+      }
+    }
+  }
+
+  def formWithConditionallyMandatoryField(booleanField: String, field: String) = {
+    s"bind when $booleanField is false and $field is omitted" in {
+      val data = validData + (booleanField -> "false") - field
+      val boundForm = form.bind(data)
+      boundForm.errors.isEmpty shouldBe true
+    }
+
+    s"fail to bind when $booleanField is true and $field is omitted" in {
+      val data = validData + (booleanField -> "true") - field
+      val expectedError = error(field, "error.required")
+      checkForError(form, data, expectedError)
+    }
+  }
+
+  def formWithBooleans(fields: String*) = {
+    for (field <- fields) {
+      s"fail to bind when $field is omitted" in {
+        val data = validData - field
+        val expectedError = error(field, "error.boolean")
+        checkForError(form, data, expectedError)
+      }
+    }
+  }
+
+  def formWithOptionField(field: String, validValues: String*) = {
+    for (validValue <- validValues) {
+      s"bind when $field is set to $validValue" in {
+        val data = validData + (field -> validValue)
+        val boundForm = form.bind(data)
+        boundForm.errors.isEmpty shouldBe true
+      }
+    }
+
+    s"fail to bind when $field is omitted" in {
+      val data = validData - field
+      val expectedError = error(field, "error.required")
+      checkForError(form, data, expectedError)
+    }
+
+    s"fail to bind when $field is invalid" in {
+      val data = validData + (field -> "invalid value")
+      val expectedError = error(field, "error.unknown")
+      checkForError(form, data, expectedError)
+    }
+  }
+  
+  def formWithDateField(field: String) = {
+    s"fail to bind when $field day is omitted" in {
+      val data = validData - s"$field.day"
+      val expectedError = error(s"$field.day", "error.date.day_blank")
+      checkForError(form, data, expectedError)
+    }
+
+    s"fail to bind when $field day is 0" in {
+      val data = validData + (s"$field.day" -> "0")
+      val expectedError = error(s"$field.day", "error.date.day_invalid")
+      checkForError(form, data, expectedError)
+    }
+
+    s"fail to bind when $field day is greater than 31" in {
+      val data = validData + (s"$field.day" -> "32")
+      val expectedError = error(s"$field.day", "error.date.day_invalid")
+      checkForError(form, data, expectedError)
+    }
+
+    s"fail to bind when $field day is negative" in {
+      val data = validData + (s"$field.day" -> "-1")
+      val expectedError = error(s"$field.day", "error.date.day_invalid")
+      checkForError(form, data, expectedError)
+    }
+
+    s"fail to bind when $field day is non-numeric" in {
+      val data = validData + (s"$field.day" -> "invalid")
+      val expectedError = error(s"$field.day", "error.date.day_invalid")
+      checkForError(form, data, expectedError)
+    }
+
+    s"fail to bind when $field month is omitted" in {
+      val data = validData - s"$field.month"
+      val expectedError = error(s"$field.month", "error.date.month_blank")
+      checkForError(form, data, expectedError)
+    }
+
+    s"fail to bind when $field month is 0" in {
+      val data = validData + (s"$field.month" -> "0")
+      val expectedError = error(s"$field.month", "error.date.month_invalid")
+      checkForError(form, data, expectedError)
+    }
+
+    s"fail to bind when $field month is greater than 12" in {
+      val data = validData + (s"$field.month" -> "13")
+      val expectedError = error(s"$field.month", "error.date.month_invalid")
+      checkForError(form, data, expectedError)
+    }
+
+    s"fail to bind when $field month is negative" in {
+      val data = validData + (s"$field.month" -> "-1")
+      val expectedError = error(s"$field.month", "error.date.month_invalid")
+      checkForError(form, data, expectedError)
+    }
+
+    s"fail to bind when $field month is non-numeric" in {
+      val data = validData + (s"$field.month" -> "invalid")
+      val expectedError = error(s"$field.month", "error.date.month_invalid")
+      checkForError(form, data, expectedError)
+    }
+
+    s"fail to bind when $field year is omitted" in {
+      val data = validData - s"$field.year"
+      val expectedError = error(s"$field.year", "error.date.year_blank")
+      checkForError(form, data, expectedError)
+    }
+
+    s"fail to bind when $field year is 0" in {
+      val data = validData + (s"$field.year" -> "0")
+      val expectedError = error(s"$field.year", "error.date.year_invalid")
+      checkForError(form, data, expectedError)
+    }
+
+    s"fail to bind when $field year is greater than 2050" in {
+      val data = validData + (s"$field.year" -> "2051")
+      val expectedError = error(s"$field.year", "error.date.year_invalid")
+      checkForError(form, data, expectedError)
+    }
+
+    s"fail to bind when $field year is negative" in {
+      val data = validData + (s"$field.year" -> "-1")
+      val expectedError = error(s"$field.year", "error.date.year_invalid")
+      checkForError(form, data, expectedError)
+    }
+
+    s"fail to bind when $field year is non-numeric" in {
+      val data = validData + (s"$field.year" -> "invalid")
+      val expectedError = error(s"$field.year", "error.date.year_invalid")
+      checkForError(form, data, expectedError)
+    }
+
+    s"fail to bind when the $field is invalid" in {
+      val data = validData + (s"$field.day" -> "30") + (s"$field.month" -> "2")
+      val expectedError = error("dateOfBirth", "error.invalid_date")
+      checkForError(form, data, expectedError)
+    }
+
+  }
+}

--- a/test/uk/gov/hmrc/residencenilratebandcalculator/forms/FormSpec.scala
+++ b/test/uk/gov/hmrc/residencenilratebandcalculator/forms/FormSpec.scala
@@ -35,4 +35,5 @@ trait FormSpec extends UnitSpec {
   def error(key: String, value: String) = Seq(FormError(key, value))
 
   lazy val emptyForm = Map[String, String]()
+
 }

--- a/test/uk/gov/hmrc/residencenilratebandcalculator/forms/IndividualSettlorFormSpec.scala
+++ b/test/uk/gov/hmrc/residencenilratebandcalculator/forms/IndividualSettlorFormSpec.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.residencenilratebandcalculator.forms
+
+import uk.gov.hmrc.residencenilratebandcalculator.models.{Date, IndividualSettlor}
+
+class IndividualSettlorFormSpec extends FormBehaviours {
+
+  val validData: Map[String, String] = Map(
+    "firstName" -> "first name",
+    "middleNames" -> "middle names",
+    "lastName" -> "last name",
+    "dateOfBirth.day" -> "1",
+    "dateOfBirth.month" -> "2",
+    "dateOfBirth.year" -> "2000",
+    "hasNino" -> "true",
+    "nino" -> "AA111111A",
+    "phoneNumber" -> "01234 567890"
+  )
+
+  val form = IndividualSettlorForm()
+
+  "Individual Settlor form" must {
+
+    behave like trustsForm[IndividualSettlor](IndividualSettlor("first name", Some("middle names"), "last name", Date(1, 2, 2000), true, Some("AA111111A"), "01234 567890"))
+
+    behave like formWithMandatoryTextFields("firstName", "lastName", "phoneNumber")
+
+    behave like formWithDateField("dateOfBirth")
+
+    behave like formWithOptionalTextFields("middleNames")
+
+    behave like formWithBooleans("hasNino")
+
+    behave like formWithConditionallyMandatoryField("hasNino", "nino")
+  }
+}

--- a/test/uk/gov/hmrc/residencenilratebandcalculator/views/CompanySettlorViewSpec.scala
+++ b/test/uk/gov/hmrc/residencenilratebandcalculator/views/CompanySettlorViewSpec.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.residencenilratebandcalculator.views
+
+import play.api.data.Form
+import uk.gov.hmrc.residencenilratebandcalculator.models.CompanySettlor
+import uk.gov.hmrc.residencenilratebandcalculator.views.html.company_settlor
+
+class CompanySettlorViewSpec extends ViewSpecBase {
+
+  val messageKeyPrefix = "company_settlor"
+
+  def createView(form: Option[Form[CompanySettlor]] = None) = company_settlor(frontendAppConfig, form)(request, messages)
+
+  "Company settlor view" must {
+    behave like trustsPage[CompanySettlor](createView, messageKeyPrefix)
+  }
+}

--- a/test/uk/gov/hmrc/residencenilratebandcalculator/views/IndividualSettlorViewSpec.scala
+++ b/test/uk/gov/hmrc/residencenilratebandcalculator/views/IndividualSettlorViewSpec.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.residencenilratebandcalculator.views
+
+import play.api.data.Form
+import uk.gov.hmrc.residencenilratebandcalculator.models.IndividualSettlor
+import uk.gov.hmrc.residencenilratebandcalculator.views.html.individual_settlor
+
+class IndividualSettlorViewSpec extends ViewSpecBase {
+
+  val messageKeyPrefix = "individual_settlor"
+
+  def createView(form: Option[Form[IndividualSettlor]] = None) = individual_settlor(frontendAppConfig, form)(request, messages)
+
+  "Individual settlor view" must {
+    behave like trustsPage[IndividualSettlor](createView, messageKeyPrefix)
+  }
+}

--- a/test/uk/gov/hmrc/residencenilratebandcalculator/views/ViewSpecBase.scala
+++ b/test/uk/gov/hmrc/residencenilratebandcalculator/views/ViewSpecBase.scala
@@ -28,9 +28,9 @@ trait ViewSpecBase extends HtmlSpec {
   val errorMessage = "error.number"
   val error = FormError(errorKey, errorMessage)
 
-  def rnrbPage[A: ClassTag](createView: (Option[Form[A]]) => HtmlFormat.Appendable,
-                            messageKeyPrefix: String,
-                            expectedGuidanceKeys: String*) = {
+  def trustsPage[A: ClassTag](createView: (Option[Form[A]]) => HtmlFormat.Appendable,
+                              messageKeyPrefix: String,
+                              expectedGuidanceKeys: String*) = {
     "behave like a standard RNRB page" when {
       "rendered" must {
         "have the correct banner title" in {


### PR DESCRIPTION
This PR illustrates what was involved in adding 2 new screens into a frontend project like RNRB.  It also involved a small amount of "plumbing" work that wasn't directly related to these screens.

Caveats - there are some pieces that should be refactored to clean up (e.g. some of the values I put in Constants should live somewhere better), and some classes, packages etc. still refer to RNRB rather than trusts as it's based off a cut-down version of RNRB rather than a clean project.

The high-level process to add a screen is to:
* Create a model (case class) for the data if necessary.  Screens with a single question don't need this step as their "model" will just be a String, Int, Boolean etc.
* Create a form to bind this case class.  Screens with a single question may be able to use the generic forms e.g. IntForm, DateForm, BooleanForm etc.
* Create a view with the content and controls you need (and add messages)
* Create a controller, which extends a generic base trait and simply specifies the form and view to use, and add the GET and POST routes
* Adjust the Navigator to include the new screen at the correct place in the flow
* [Optionally] adjust the CascadeUpsert class to do any cleanup required (e.g. sometimes when a user goes back and changes an answer, we want to discard some other answers they've provided).